### PR TITLE
Fixed issue with adding new todo items.

### DIFF
--- a/ToDoList/ToDoListTableViewController.swift
+++ b/ToDoList/ToDoListTableViewController.swift
@@ -16,6 +16,9 @@ class ToDoListTableViewController: UITableViewController {
 	
 	override func viewDidLoad() {
 		super.viewDidLoad()
+		
+	        tableView.registerClass(ToDoItemCell.self, forCellReuseIdentifier: ToDoItemCell.identifier)
+	        
 		if let stateController = stateController {
 			tableViewDataSource = TableViewDataSource(tableView: tableView, stateController: stateController)
 			tableViewDelegate = TableViewDelegate(tableView: tableView, stateController: stateController)


### PR DESCRIPTION
After adding a new todo item, app would crash due to dequeueReusableCellWithIdentifier not being able to find a cell instance with the registered identifier.
